### PR TITLE
Added a note to the readme about some recent changes we've made to work ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Conveniently display all of your active [Kiln](https://www.fogcreek.com/kiln/) [
 
 To use it, set `kilnUrlBase` in the web.config to your kiln base url, e.g., https://example.kilnhg.com/, and log in with your FogBugz details.
 
+####Note:
+
+After a recent update to Kiln, this code will work with Harmony repositories and Git-only repositories but **won't work with Mercurial-only repositories**. See [this commit](https://github.com/NonlinearDynamics/KilnReviewDashboard/commit/778dd44ddeee6b73b06008384cf06a131c568f9c) for more information.
+
 ### FogBugz Integration
 
 You can also integrate with FogBugz, which will add a section showing you:


### PR DESCRIPTION
...with Git-only repositories which now means the code doesn't work with Mercurial-only repositories.

Kiln now allows you to choose the VCS of a repository on creation, i.e., Mercurial only,
Git only, or Harmony (Git & Mercurial).

Since this update, the API calls we were using stopped working for Git-only repositories.
The suggested fix from Fog Creek tech support is to add `&vcs=2` to the URL. This makes
the API calls work for Harmony repositories and Git-only repositories, but *not*
Mercurial-only repositories.

(This is fine for us as we don't have any Mercurial-only repositories but I thought it best
to highlight the issue in the readme to avoid confusion if anyone else tries to use it. If they
have Mercurial-only repositories it may need an alternative fix!)